### PR TITLE
Changing the sass files path on watch task config in Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,7 +126,7 @@ module.exports = function(grunt) {
         // tasks: ['jshint:gruntfile']
       },
       sass: {
-        files: ['stylesheets/**/*.scss'],
+        files: ['sass/**/*.scss'],
         tasks: ['sass'],
         options: {
           livereload: true


### PR DESCRIPTION
I found that the sass watch plugin wasn't actually watching the proper files, and I made this little change.
@gormus, could you take a look? you are the Grunt expert :P 
